### PR TITLE
test for gitlab ci bug

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ stages:
 
 on-pull-requests:
   stage: test
-  script: echo 'this should run on pull requests'
+  script: echo 'this should run on pull requests. Edit for PR'
   only:
     - external_pull_requests
 


### PR DESCRIPTION
When I open/reopen this PR, a pipeline in https://gitlab.com/kzap/gitlab-external-pr-bug/pipelines should be triggered but it will fail because the gitlab-ci references a private repository that the Pipeline cannot be accessed because its being triggered by `API`